### PR TITLE
Improved efficiency in StreamPowerLaw and FLexure

### DIFF
--- a/Flexure2D_v1.0/src/flexure2D.f90
+++ b/Flexure2D_v1.0/src/flexure2D.f90
@@ -51,6 +51,7 @@ subroutine flexure (hh2,hp2,nx,ny,xl,yl,rhos2,rhoa,eet,ibc)
   do while (nflex.lt.max(nx,ny))
     nflex=nflex*2
   enddo
+  nflex=nflex/2
 
   allocate (w(nflex,nflex))
 

--- a/src/StreamPowerLaw.f90
+++ b/src/StreamPowerLaw.f90
@@ -285,6 +285,7 @@ subroutine StreamPowerLaw ()
     endif
 
     err=maxval(abs(h-hp))
+    if (maxval(g).lt.tiny(g)) err=0.d0
 
   enddo
 


### PR DESCRIPTION
Note for @benbovy : I have limited the number of GS iterations to 1 in StreamPowerLaw when G=0; I have also decreased the resolution of the flexure code by a factor 2 to make it similar to the original FastScape code.