### PR TITLE
Fixed bug in StreamPowerLaw.f90 that prevented the sediment lake fill…

### DIFF
--- a/src/StreamPowerLaw.f90
+++ b/src/StreamPowerLaw.f90
@@ -162,8 +162,6 @@ subroutine StreamPowerLaw ()
     ! calculate erosion/deposition at each node
     dh=ht-hp
 
-    lake_sill = 0
-
     ! sum the erosion in stack order
     do ij=1,nn
       ijk=mstack(ij)


### PR DESCRIPTION
…ing algorithm to work properly, especially when flexure was used and large depressions/lakes were created
During testing I had reset the lake_fill array to zero at every iteration of the Gauss-Seidl loop. Removing this has fixed a major issue with Lake filling algorithm (mass loss and/or too much bypass of sediment in the lake filling)