### PR TITLE
Some changes for more flexibility downstream

### DIFF
--- a/docs/api.adoc
+++ b/docs/api.adoc
@@ -138,7 +138,7 @@ bedrock dimensionless deposition/transport coefficient for the enriched SPL (dou
 
 [WARNING]
 ====
-When `g > 0`, the algorithm requires that Gauss-Seidel iterations be performed; depending on the value of `g`, the number of iterations can be significant (from 1 when `g` is near 0 to 20 when `g` is near 1)
+When `g > 0`, the algorithm requires that Gauss-Seidel iterations be performed; depending on the value of `g`, the number of iterations can be significant (from 1 when `g` is near 0 to 20 when `g` is near 1). `g` must be equal or greater than zero.
 ====
 
 `gsed` ::

--- a/docs/release_notes.adoc
+++ b/docs/release_notes.adoc
@@ -1,6 +1,12 @@
 [#release_notes]
 == Release notes
 
+=== Version 2.8.2 (Unreleased)
+
+==== Bug fixes
+
+- Some internal changes for more flexibility downstream #25
+
 === Version 2.8.1 (13 October 2019)
 
 ==== Bug fixes

--- a/src/FastScape_api.f90
+++ b/src/FastScape_api.f90
@@ -223,10 +223,12 @@ subroutine FastScape_Execute_Step()
   if (runSPL) then
     call cpu_time (time_in)
     if (SingleFlowDirection) then
-      call FlowRoutingSingleFlowDirection
+      call FlowRoutingSingleFlowDirection ()
+      call FlowAccumulationSingleFlowDirection ()
       call StreamPowerLawSingleFlowDirection ()
     else
       call FlowRouting ()
+      call FlowAccumulation ()
       call StreamPowerLaw ()
     endif
     call cpu_time (time_out)

--- a/src/FastScape_ctx.f90
+++ b/src/FastScape_ctx.f90
@@ -12,6 +12,7 @@ module FastScapeContext
   logical :: setup_has_been_run
   double precision, target, dimension(:), allocatable :: h,u,vx,vy,length,a,erate,etot,catch,catch0,b,precip,kf,kd
   double precision, target, dimension(:), allocatable :: Sedflux, Fmix
+  double precision, target, dimension(:), allocatable :: g
   double precision, dimension(:,:), pointer, contiguous :: h2, vx2, vy2, etot2, b2
   double precision :: xl, yl, dt, kfsed, m, n, kdsed, g1, g2, p
   double precision :: sealevel, poro1, poro2, zporo1, zporo2, ratio, layer, kdsea1, kdsea2
@@ -60,6 +61,7 @@ module FastScapeContext
     call Destroy()
 
     allocate (h(nn),u(nn),vx(nn),vy(nn),stack(nn),ndon(nn),rec(nn),don(8,nn),catch0(nn),catch(nn),precip(nn))
+    allocate (g(nn))
     allocate (length(nn),a(nn),erate(nn),etot(nn),b(nn),Sedflux(nn),Fmix(nn),kf(nn),kd(nn))
     allocate (lake_depth(nn),hwater(nn),mrec(8,nn),mnrec(nn),mwrec(8,nn),mlrec(8,nn),mstack(nn))
 
@@ -135,6 +137,7 @@ module FastScapeContext
     if (allocated(mwrec)) deallocate(mwrec)
     if (allocated(mlrec)) deallocate(mlrec)
     if (allocated(mstack)) deallocate(mstack)
+    if (allocated(g)) deallocate(g)
 
 
     return

--- a/src/FastScape_ctx.f90
+++ b/src/FastScape_ctx.f90
@@ -13,6 +13,7 @@ module FastScapeContext
   double precision, target, dimension(:), allocatable :: h,u,vx,vy,length,a,erate,etot,catch,catch0,b,precip,kf,kd
   double precision, target, dimension(:), allocatable :: Sedflux, Fmix
   double precision, target, dimension(:), allocatable :: g
+  double precision, target, dimension(:), allocatable :: p_mfd_exp
   double precision, dimension(:,:), pointer, contiguous :: h2, vx2, vy2, etot2, b2
   double precision :: xl, yl, dt, kfsed, m, n, kdsed, g1, g2, p
   double precision :: sealevel, poro1, poro2, zporo1, zporo2, ratio, layer, kdsea1, kdsea2
@@ -62,6 +63,7 @@ module FastScapeContext
 
     allocate (h(nn),u(nn),vx(nn),vy(nn),stack(nn),ndon(nn),rec(nn),don(8,nn),catch0(nn),catch(nn),precip(nn))
     allocate (g(nn))
+    allocate (p_mfd_exp(nn))
     allocate (length(nn),a(nn),erate(nn),etot(nn),b(nn),Sedflux(nn),Fmix(nn),kf(nn),kd(nn))
     allocate (lake_depth(nn),hwater(nn),mrec(8,nn),mnrec(nn),mwrec(8,nn),mlrec(8,nn),mstack(nn))
 
@@ -83,6 +85,7 @@ module FastScapeContext
     etot = 0.d0
     b = h
     precip = 1.d0
+    p_mfd_exp(1:nn) = 1.d0
     call random_number (catch0)
     sealevel = 0.d0
     Fmix = 0.5d0
@@ -138,6 +141,7 @@ module FastScapeContext
     if (allocated(mlrec)) deallocate(mlrec)
     if (allocated(mstack)) deallocate(mstack)
     if (allocated(g)) deallocate(g)
+    if (allocated(p_mfd_exp)) deallocate(p_mfd_exp)
 
 
     return
@@ -427,6 +431,7 @@ module FastScapeContext
     g1 = gg1
     g2 = gg2
     p = pp
+    p_mfd_exp(1:nn) = pp
     SingleFlowDirection = .false.
     if (pp.lt.-1.5d0) then
       SingleFlowDirection = .true.
@@ -838,7 +843,7 @@ module FastScapeContext
 
       ! computes receiver and stack information for multi-direction flow
       !allocate (mrec(8,nn), mnrec(nn), mwrec(8,nn), mlrec(8,nn), mstack(nn), hwater(nn)
-      !call find_mult_rec (h, rec, stack, hwater, mrec, mnrec, mwrec, mlrec, mstack, nx, ny, xl/(nx-1), yl/(ny-1), p, ibc)
+      !call find_mult_rec (h, rec, stack, hwater, mrec, mnrec, mwrec, mlrec, mstack, nx, ny, xl/(nx-1), yl/(ny-1), p, ibc, p_mfd_exp)
       ! computes sediment flux
       allocate (flux(nn), bc(nn))
 

--- a/src/FlowRouting.f90
+++ b/src/FlowRouting.f90
@@ -106,6 +106,56 @@ end subroutine FlowRoutingSingleFlowDirection
 
 !--------------------------------------------------------------------------------------------
 
+subroutine FlowAccumulation ()
+
+  use FastScapeContext
+
+  implicit none
+
+  integer :: ij, ijk, k
+  double precision :: dx,dy
+
+  dx=xl/(nx-1)
+  dy=yl/(ny-1)
+
+  a=dx*dy*precip
+  do ij=1,nn
+    ijk=mstack(ij)
+    do k =1,mnrec(ijk)
+      a(mrec(k,ijk))=a(mrec(k,ijk))+a(ijk)*mwrec(k,ijk)
+    enddo
+  enddo
+
+  return
+
+end subroutine FlowAccumulation
+
+!--------------------------------------------------------------------------------------------
+
+subroutine FlowAccumulationSingleFlowDirection ()
+
+  use FastScapeContext
+
+  implicit none
+
+  integer :: ij, ijk
+  double precision :: dx,dy
+
+  dx=xl/(nx-1)
+  dy=yl/(ny-1)
+
+  a=dx*dy*precip
+  do ij=nn,1,-1
+    ijk=stack(ij)
+    a(rec(ijk))=a(rec(ijk))+a(ijk)
+  enddo
+
+  return
+
+end subroutine FlowAccumulationSingleFlowDirection
+
+!--------------------------------------------------------------------------------------------
+
 subroutine find_mult_rec (h,rec0,stack0,water,rec,nrec,wrec,lrec,stack,nx,ny,dx,dy,p,ibc,p_mfd_exp)
 
   ! subroutine to find multiple receiver information

--- a/src/FlowRouting.f90
+++ b/src/FlowRouting.f90
@@ -38,7 +38,7 @@ subroutine FlowRouting ()
   deallocate (bc)
 
   ! computes receiver and stack information for mult-direction flow
-  call find_mult_rec (h,rec,stack,hwater,mrec,mnrec,mwrec,mlrec,mstack,nx,ny,dx,dy,p,ibc)
+  call find_mult_rec (h,rec,stack,hwater,mrec,mnrec,mwrec,mlrec,mstack,nx,ny,dx,dy,p,ibc,p_mfd_exp)
 
   return
 
@@ -106,7 +106,7 @@ end subroutine FlowRoutingSingleFlowDirection
 
 !--------------------------------------------------------------------------------------------
 
-subroutine find_mult_rec (h,rec0,stack0,water,rec,nrec,wrec,lrec,stack,nx,ny,dx,dy,p,ibc)
+subroutine find_mult_rec (h,rec0,stack0,water,rec,nrec,wrec,lrec,stack,nx,ny,dx,dy,p,ibc,p_mfd_exp)
 
   ! subroutine to find multiple receiver information
   ! in input:
@@ -126,11 +126,11 @@ subroutine find_mult_rec (h,rec0,stack0,water,rec,nrec,wrec,lrec,stack,nx,ny,dx,
   ! stack: stoack order for multiple receivers (from top to bottom)
 
   integer nx,ny,ibc
-  double precision h(nx*ny),wrec(8,nx*ny),lrec(8,nx*ny),dx,dy,p,water(nx*ny)
+  double precision h(nx*ny),wrec(8,nx*ny),lrec(8,nx*ny),dx,dy,p,water(nx*ny),p_mfd_exp(nx*ny)
   integer rec(8,nx*ny),nrec(nx*ny),stack(nx*ny),rec0(nx*ny),stack0(nx*ny)
 
   integer :: nn,i,j,ii,jj,iii,jjj,ijk,k,ijr,nparse,nstack,ijn,i1,i2,j1,j2
-  double  precision :: slopemax,pp,sumweight,deltah
+  double  precision :: slopemax,sumweight,deltah
   integer, dimension(:), allocatable :: ndon,vis,parse
   integer, dimension(:,:), allocatable :: don
   double precision, dimension(:), allocatable :: h0
@@ -207,14 +207,13 @@ subroutine find_mult_rec (h,rec0,stack0,water,rec,nrec,wrec,lrec,stack,nx,ny,dx,
   enddo
 
   do ij =1,nn
-    pp = p
-    if (pp<0.d0) then
+    if (p<0.d0) then
       slope = 0.d0
       if (nrec(ij).ne.0) slope = real(sum(wrec(1:nrec(ij),ij))/nrec(ij))
-      pp = 0.5 + 0.6*slope
+      p_mfd_exp(ij) = 0.5 + 0.6*slope
     endif
     do k=1,nrec(ij)
-      wrec(k,ij) = wrec(k,ij)**pp
+      wrec(k,ij) = wrec(k,ij)**p_mfd_exp(ij)
     enddo
     sumweight = sum(wrec(1:nrec(ij),ij))
     wrec(1:nrec(ij),ij) = wrec(1:nrec(ij),ij)/sumweight

--- a/src/Marine.f90
+++ b/src/Marine.f90
@@ -53,7 +53,7 @@ subroutine Marine()
 
   allocate (mmrec(8,nn),mmnrec(nn),mmwrec(8,nn),mmlrec(8,nn),mmstack(nn),mwater(nn))
 
-  call find_mult_rec (h,rec,stack,mwater,mmrec,mmnrec,mmwrec,mmlrec,mmstack,nx,ny,dx,dy,0.d0,ibc)
+  call find_mult_rec (h,rec,stack,mwater,mmrec,mmnrec,mmwrec,mmlrec,mmstack,nx,ny,dx,dy,0.d0,ibc,p_mfd_exp)
 
   !print*,count(flux>0.and.mmnrec==0),count(flux>0),count(mmstack==0)
 

--- a/src/StreamPowerLaw.f90
+++ b/src/StreamPowerLaw.f90
@@ -25,10 +25,15 @@ subroutine StreamPowerLaw ()
   dx=xl/(nx-1)
   dy=yl/(ny-1)
 
-  ! defines g, dimensionless parameter for sediment transport and deposition
-  g=g1
+  ! set g, dimensionless parameter for sediment transport and deposition
+  ! if g1<0, skip and use g values directly from FastScapeContext (not in API!!!)
+  if (g1.ge.0.d0) then
+    g=g1
+    if (g2.gt.0.d0) where ((h-b).gt.1.d0) g=g2
+  endif
+
+  ! set kf / kfsed
   kfint=kf
-  if (g2.gt.0.d0) where ((h-b).gt.1.d0) g=g2
   if (kfsed.gt.0.d0) where ((h-b).gt.1.d0) kfint=kfsed
 
   lake_depth = hwater - h
@@ -239,17 +244,16 @@ subroutine StreamPowerLaw ()
     dx=xl/(nx-1)
     dy=yl/(ny-1)
 
-    ! defines g, dimensionless parameter for sediment transport and deposition
-    g=g1
+    ! set g, dimensionless parameter for sediment transport and deposition
+    ! if g1<0, skip and use g values directly from FastScapeContext (not in API!!!)
+    if (g1.ge.0.d0) then
+      g=g1
+      if (g2.gt.0.d0) where ((h-b).gt.1.d0) g=g2
+    endif
+
+    ! set kf / kfsed
     kfint=kf
-    if (g2.gt.0.d0) where ((h-b).gt.1.d0) g=g2
     if (kfsed.gt.0.d0) where ((h-b).gt.1.d0) kfint=kfsed
-
-    ! uplift
-
-!    h=h+u*dt
-
-    ! computes receiver and stack information for mult-direction flow
 
     lake_depth = hwater - h
 

--- a/src/StreamPowerLaw.f90
+++ b/src/StreamPowerLaw.f90
@@ -12,13 +12,13 @@ subroutine StreamPowerLaw ()
   integer :: ij,ijk,ijr,k,ijr1
   double precision :: dx,dy,fact,tol,err
   double precision :: f,df,errp,h0,hn,omega,tolp,w_rcv
-  double precision, dimension(:), allocatable :: ht,g,kfint,dh,hp
+  double precision, dimension(:), allocatable :: ht,kfint,dh,hp
   double precision, dimension(:), allocatable :: elev
   logical, dimension(:), allocatable :: bc
   double precision, dimension(:), allocatable :: water,lake_water_volume,lake_sediment
   integer, dimension(:), allocatable :: lake_sill
 
-  allocate (ht(nn),g(nn),kfint(nn),bc(nn),dh(nn),hp(nn))
+  allocate (ht(nn),kfint(nn),bc(nn),dh(nn),hp(nn))
   allocate (elev(nn))
   allocate (water(nn),lake_water_volume(nn),lake_sediment(nn),lake_sill(nn))
 
@@ -224,13 +224,13 @@ subroutine StreamPowerLaw ()
     integer :: ij,ijk,ijr
     double precision :: dx,dy,fact,tol,err
     double precision :: f,df,errp,h0,hn,omega,tolp,w_rcv
-    double precision, dimension(:), allocatable :: ht,g,kfint,dh,hp
+    double precision, dimension(:), allocatable :: ht,kfint,dh,hp
     double precision, dimension(:), allocatable :: elev
     logical, dimension(:), allocatable :: bc
     double precision, dimension(:), allocatable :: water,lake_water_volume,lake_sediment
     integer, dimension(:), allocatable :: lake_sill
 
-    allocate (ht(nn),g(nn),kfint(nn),bc(nn),dh(nn),hp(nn))
+    allocate (ht(nn),kfint(nn),bc(nn),dh(nn),hp(nn))
     allocate (elev(nn))
     allocate (water(nn),lake_water_volume(nn),lake_sediment(nn),lake_sill(nn))
 

--- a/src/StreamPowerLaw.f90
+++ b/src/StreamPowerLaw.f90
@@ -40,15 +40,6 @@ subroutine StreamPowerLaw ()
 
   if (count(mstack==0).ne.0) print*,'incomplete stack',count(mstack==0),nn
 
-  ! computes drainage area
-  a=dx*dy*precip
-  do ij=1,nn
-    ijk=mstack(ij)
-    do k =1,mnrec(ijk)
-      a(mrec(k,ijk))=a(mrec(k,ijk))+a(ijk)*mwrec(k,ijk)
-    enddo
-  enddo
-
   ! calculate the elevation / SPL, including sediment flux
   tol=1.d-4*(maxval(abs(h)) + 1.d0)
   err=2.d0*tol
@@ -256,13 +247,6 @@ subroutine StreamPowerLaw ()
     if (kfsed.gt.0.d0) where ((h-b).gt.1.d0) kfint=kfsed
 
     lake_depth = hwater - h
-
-    ! computes drainage area
-    a=dx*dy*precip
-    do ij=nn,1,-1
-      ijk=stack(ij)
-      a(rec(ijk))=a(rec(ijk))+a(ijk)
-    enddo
 
     ! calculate the elevation / SPL, including sediment flux
     tol=1.d-4*(maxval(abs(h))+1.d0)


### PR DESCRIPTION
Those changes are needed to fully leverage `fastscapelib-fortran` in [fastscape](https://github.com/fastscape-lem/fastscape) while enabling more customization.

I exploit the fact that all variables declared in `FastScapeContext` are exposed to python (i.e., from `fastscapelib_fortran.fastscapecontext` attribute), which allows me to do more customization than what is possible by using the API (`FastScape_api.f90`).

