### PR TITLE
Deallocated various arrays in StreamPowerLaw.f90

### DIFF
--- a/src/StreamPowerLaw.f90
+++ b/src/StreamPowerLaw.f90
@@ -209,6 +209,8 @@ subroutine StreamPowerLaw ()
     Sedflux=ht-h
     !if (runMarine) where (h.lt.sealevel) Sedflux=0.d0
 
+    deallocate (ht,kfint,dh,hp,elev,bc,water,lake_water_volume,lake_sediment,lake_sill)
+
     return
 
   end subroutine StreamPowerLaw
@@ -410,6 +412,8 @@ subroutine StreamPowerLaw ()
       erate=(ht-h)/dt
       Sedflux=ht-h
       !if (runMarine) where (h.lt.sealevel) Sedflux=0.d0
+
+      deallocate (ht,kfint,dh,hp,elev,bc,water,lake_water_volume,lake_sediment,lake_sill)
 
       return
 


### PR DESCRIPTION
This is a simple fix to issue #31. A bunch of temporary arrays was not deallocated in the two main subroutines of StreamPowerLaw.f90. This is not a fundamental issue in Fortran 90 but is cleaner and safer to always deallocate temporary arrays although they are supposed to be deallocated automatically when exiting the subroutine.