### PR TITLE
Added missing type declaration statements.

### DIFF
--- a/src/FlowRouting.f90
+++ b/src/FlowRouting.f90
@@ -170,8 +170,8 @@ subroutine find_mult_rec (h,rec0,stack0,water,rec,nrec,wrec,lrec,stack,nx,ny,dx,
   double precision h(nx*ny),wrec(8,nx*ny),lrec(8,nx*ny),dx,dy,p,water(nx*ny),p_mfd_exp(nx*ny)
   integer rec(8,nx*ny),nrec(nx*ny),stack(nx*ny),rec0(nx*ny),stack0(nx*ny)
 
-  integer :: nn,i,j,ii,jj,iii,jjj,ijk,k,ijr,nparse,nstack,ijn
-  double  precision :: slopemax,sumweight,deltah
+  integer :: nn,i,j,ii,jj,iii,jjj,ijk,k,ijr,nparse,nstack,ijn,ij
+  double  precision :: slopemax,sumweight,deltah,slope
   integer, dimension(:), allocatable :: ndon,vis,parse
   integer, dimension(:,:), allocatable :: don
   double precision, dimension(:), allocatable :: h0

--- a/src/VTK.f90
+++ b/src/VTK.f90
@@ -142,7 +142,7 @@ subroutine VTK_filled (basement, nreflector, reflector, nfield, fields, names, n
   ! in ASCII format (not binary); this means that the files it generates are larger and take more time
   ! to load into Paraview
 
-  integer :: nx, ny, nreflector, nfield, istep
+  integer :: nx, ny, nreflector, nfield, istep, i, j, k, l, ij 
   double precision basement(nx*ny), reflector(nx*ny,nreflector), dx, dy, vex, distb(nx*ny)
   double precision fields(nx*ny,nfield,nreflector)
   character*30 names(nfield)


### PR DESCRIPTION
Added some type declaration statements that threw an error during compilation for coupling with a thermo-mechanical model. I compiled with a (simple) but extra Makefile.
Note also that the subroutine find_mult_rec() in src/FlowRouting.f90 is not initiated with 'implicit none'.
