### PR TITLE
Added subroutine to set absolute tolerance of stream power law

### DIFF
--- a/src/FastScape_api.f90
+++ b/src/FastScape_api.f90
@@ -772,3 +772,19 @@ subroutine FastScape_Get_Fluxes (ttectonic_flux, eerosion_flux, bboundary_flux)
   return
 
 end subroutine FastScape_Get_Fluxes
+
+!--------------------------------------------------------------------------
+
+subroutine FastScape_Set_Tolerance_SPL (atol_SPLp)
+
+  use FastScapeContext
+
+  implicit none
+
+  double precision, intent(in) :: atol_SPLp
+
+  call SetAtolSPL (atol_SPLp)
+
+  return
+
+end subroutine FastScape_Set_Tolerance_SPL

--- a/src/FastScape_ctx.f90
+++ b/src/FastScape_ctx.f90
@@ -34,6 +34,7 @@ module FastScapeContext
   integer, dimension(:), allocatable :: mnrec,mstack
   integer, dimension(:,:), allocatable :: mrec
   double precision, dimension(:,:), allocatable :: mwrec,mlrec
+  double precision :: atol_SPL
 
   contains
 
@@ -107,6 +108,8 @@ module FastScapeContext
     nGSMarine = 0
 
     setup_has_been_run = .true.
+
+    atol_SPL = -1.d0
 
     return
 
@@ -884,5 +887,18 @@ module FastScapeContext
       deallocate (flux)
 
     end subroutine compute_fluxes
+
+
+    !---------------------------------------------------------------
+
+    subroutine SetAtolSPL (atol_SPLp)
+
+      double precision, intent(in) ::atol_SPLp
+
+      atol_SPL = atol_SPLp
+
+      return
+
+    end subroutine SetAtolSPL
 
   end module FastScapeContext

--- a/src/StreamPowerLaw.f90
+++ b/src/StreamPowerLaw.f90
@@ -39,6 +39,7 @@ subroutine StreamPowerLaw ()
 
   ! calculate the elevation / SPL, including sediment flux
   tol=1.d-4*(maxval(abs(h)) + 1.d0)
+  if (atol_SPL > 0.d0) tol = atol_SPL
   err=2.d0*tol
 
   ! store the elevation at t
@@ -244,6 +245,7 @@ subroutine StreamPowerLaw ()
 
     ! calculate the elevation / SPL, including sediment flux
     tol=1.d-4*(maxval(abs(h))+1.d0)
+    if (atol_SPL > 0.d0) tol = atol_SPL
     err=2.d0*tol
 
     ! store the elevation at t


### PR DESCRIPTION
The current implementation of tol=1.d-4*(maxval(abs(h))+1.d0) can give high tolerance values for instance when fastscape's sealevel is at elevation of 600 km and the maximum elevation is 605 km. This can easily happen when coupling fastscape to a thermo-mechanical model that has the origin at the lower model boundary. Setting the default tolerance as done here should be re-considered.