### PR TITLE
Expose SPL convergence parameters

### DIFF
--- a/docs/api.adoc
+++ b/docs/api.adoc
@@ -341,6 +341,38 @@ Arguments:
 
 array of dimension `(nx*ny)` containing the topographic increment in meters to be added to the topography `h`, the basement `b` and the stratigraphic horizons created when the **Stratigraphy** option has been turned on by calling the `FastScape_Strati` routine (double precision)
 
+=== FastScape_Set_Tolerance
+
+This routine can be used to set the convergence parameters for the Gauss-Seidel iterations performed while numerically solving the Stream Power law.
+
+Arguments:
+
+`FastScape_Set_Tolerance ( tol_relp, tol_absp, nGSStreamPowerLawMaxp)`
+
+`tol_relp` ::
+
+relative tolerance (applied to the current max. topographic elevation)
+
+`tol_absp` ::
+
+absolute tolerance
+
+`nGSStreamPowerLawMaxp` ::
+
+maximum number of Gauss-Seidel iterations
+
+=== FastScape_Get_GSSIterations
+
+This routine is used to get the actual number of Gauss-Seidel iterations performed while numerically solving the Stream Power law during the last time step.
+
+Arguments:
+
+`FastScape_Get_GSSIterations ( nGSSp)`
+
+`nGSSp` ::
+
+number of Gauss-Seidel iterations
+
 === FastScape_Copy_H
 
 This routine is used to extract from the model the current topography in meters

--- a/src/FastScape_api.f90
+++ b/src/FastScape_api.f90
@@ -772,3 +772,36 @@ subroutine FastScape_Get_Fluxes (ttectonic_flux, eerosion_flux, bboundary_flux)
   return
 
 end subroutine FastScape_Get_Fluxes
+
+!--------------------------------------------------------------------------
+
+subroutine FastScape_Set_Tolerance (tol_relp, tol_absp, nGSStreamPowerLawMaxp)
+
+  use FastScapeContext
+
+  implicit none
+
+  double precision :: tol_relp, tol_absp
+  integer :: nGSStreamPowerLawMaxp
+
+  call set_tolerance (tol_relp, tol_absp, nGSStreamPowerLawMaxp)
+
+  return
+
+end subroutine FastScape_Set_Tolerance
+
+!--------------------------------------------------------------------------
+
+subroutine FastScape_Get_GSSIterations (nGSSp)
+
+  use FastScapeContext
+
+  implicit none
+
+  integer :: nGSSp
+
+  call get_nGSSiterations (nGSSp)
+
+  return
+
+end subroutine FastScape_Get_GSSIterations

--- a/src/FastScape_ctx.f90
+++ b/src/FastScape_ctx.f90
@@ -14,6 +14,8 @@ module FastScapeContext
   integer :: step
   integer :: nGSStreamPowerLaw, nGSMarine
   logical :: setup_has_been_run
+  double precision :: tol_rel, tol_abs
+  integer :: nGSStreamPowerLawMax
   double precision, target, dimension(:), allocatable :: h,u,vx,vy,length,a,erate,etot,catch,catch0,b,precip,kf,kd
   double precision, target, dimension(:), allocatable :: Sedflux, Fmix
   double precision, target, dimension(:), allocatable :: g
@@ -34,7 +36,6 @@ module FastScapeContext
   integer, dimension(:), allocatable :: mnrec,mstack
   integer, dimension(:,:), allocatable :: mrec
   double precision, dimension(:,:), allocatable :: mwrec,mlrec
-
   contains
 
   subroutine Init()
@@ -107,6 +108,10 @@ module FastScapeContext
     nGSMarine = 0
 
     setup_has_been_run = .true.
+
+    tol_rel = 1e-3
+    tol_abs = 1e-3
+    nGSStreamPowerLawMax = 100
 
     return
 
@@ -885,4 +890,37 @@ module FastScapeContext
 
     end subroutine compute_fluxes
 
+!---------------------------------------------------------------
+
+    subroutine set_tolerance (rel, abs, nGSSmax)
+
+      ! internal routine to set the relative and aboslute tolerance and maximum 
+      ! number of GSS iterations for the streamPowerLaw that includes sediment
+
+      implicit none
+
+      double precision :: rel, abs
+      integer :: nGSSmax
+
+      tol_rel = rel
+      tol_abs = abs
+      nGSStreamPowerLawMax = nGSSmax
+
+    end subroutine set_tolerance
+  
+!---------------------------------------------------------------
+
+    subroutine get_nGSSiterations (nGSS)
+
+      ! internal routine to get the number of GSS iterations for the
+      ! StreamPowerLaw computations (with sediment)
+  
+      implicit none
+  
+      integer :: nGSS
+  
+      nGSS = nGSStreamPowerLaw
+  
+    end subroutine get_nGSSiterations
+  
   end module FastScapeContext

--- a/src/FastScape_ctx.f90
+++ b/src/FastScape_ctx.f90
@@ -109,8 +109,8 @@ module FastScapeContext
 
     setup_has_been_run = .true.
 
-    tol_rel = 1e-3
-    tol_abs = 1e-3
+    tol_rel = 1.d-4
+    tol_abs = 1.d-4
     nGSStreamPowerLawMax = 100
 
     return

--- a/src/StreamPowerLaw.f90
+++ b/src/StreamPowerLaw.f90
@@ -37,9 +37,6 @@ subroutine StreamPowerLaw ()
 
   if (count(mstack==0).ne.0) print*,'incomplete stack',count(mstack==0),nn
 
-  ! calculate the elevation / SPL, including sediment flux
-  ! Jean Braun modification on 18/11/2022: decreased tolerance to 10^-6
-  ! tol=1.d-6*(maxval(abs(h)) + 1.d0)
   ! modified by Jean Braun (20/11/2022) to allow for relative versus
   ! absolute tolerance
   tol = tol_rel*maxval(abs(h)) + tol_abs
@@ -251,9 +248,6 @@ subroutine StreamPowerLaw ()
     kfint=kf
     if (kfsed.gt.0.d0) where ((h-b).gt.1.d0) kfint=kfsed
 
-    ! calculate the elevation / SPL, including sediment flux
-    ! Jean Braun modification on 18/11/2022: decreased tolerance to 10^-6
-    tol=1.d-6*(maxval(abs(h)) + 1.d0)
     ! modified by Jean Braun (20/11/2022) to allow for relative versus
     ! absolute tolerance
     tol = tol_rel*maxval(abs(h)) + tol_abs 

--- a/src/StreamPowerLaw.f90
+++ b/src/StreamPowerLaw.f90
@@ -39,7 +39,10 @@ subroutine StreamPowerLaw ()
 
   ! calculate the elevation / SPL, including sediment flux
   ! Jean Braun modification on 18/11/2022: decreased tolerance to 10^-6
-  tol=1.d-6*(maxval(abs(h)) + 1.d0)
+  ! tol=1.d-6*(maxval(abs(h)) + 1.d0)
+  ! modified by Jean Braun (20/11/2022) to allow for relative versus
+  ! absolute tolerance
+  tol = tol_rel*maxval(abs(h)) + tol_abs
   err=2.d0*tol
 
   ! store the elevation at t
@@ -53,7 +56,7 @@ subroutine StreamPowerLaw ()
   dh=0.d0
   hp=h
   
-  do while (err.gt.tol.and.nGSStreamPowerLaw.lt.99)
+  do while (err.gt.tol.and.nGSStreamPowerLaw.lt.nGSStreamPowerLawMax-1)
     nGSStreamPowerLaw=nGSStreamPowerLaw+1
 
     where (bounds_bc)
@@ -251,6 +254,9 @@ subroutine StreamPowerLaw ()
     ! calculate the elevation / SPL, including sediment flux
     ! Jean Braun modification on 18/11/2022: decreased tolerance to 10^-6
     tol=1.d-6*(maxval(abs(h)) + 1.d0)
+    ! modified by Jean Braun (20/11/2022) to allow for relative versus
+    ! absolute tolerance
+    tol = tol_rel*maxval(abs(h)) + tol_abs 
     err=2.d0*tol
 
     ! store the elevation at t
@@ -263,7 +269,7 @@ subroutine StreamPowerLaw ()
     dh=0.d0
     hp=h
 
-    do while (err.gt.tol.and.nGSStreamPowerLaw.lt.99)
+    do while (err.gt.tol.and.nGSStreamPowerLaw.lt.nGSStreamPowerLawMax-1)
       nGSStreamPowerLaw=nGSStreamPowerLaw+1
       where (bounds_bc)
         elev=ht


### PR DESCRIPTION
@benbovy

In response to our discussion on the GSS tolerance issue, I have (re)adjusted the modifications made during the previous pull request and merge.

I have added a routine to the api and context to allow for the setting of three parameters:
- a relative tolerance
- an absolute tolerance
- a maximum number of iterations
for the stream power law algorithm that requires Gauss-Siedel iterations to take into account sediment deposition (see Yuan et al, 2019)

As in the previous pull request, I have removed the print statement that warns about the number of iterations having reached the limit

I have also added a routine to the api and context to obtain on demand the number of iterations performed during the GSS iteration loop