### PR TITLE
Update source and online documentation of silt fraction

### DIFF
--- a/docs/api.adoc
+++ b/docs/api.adoc
@@ -175,19 +175,19 @@ sea level in meters (double precision)
 
 `p1`::
 
-reference/surface porosity for sand (double precision)
+reference/surface porosity for silt (double precision)
 
 `p2`::
 
-reference/surface porosity for silt (double precision)
+reference/surface porosity for sand (double precision)
 
 `z1`::
 
-e-folding depth for exponential porosity law for sand (double precision)
+e-folding depth for exponential porosity law for silt (double precision)
 
 `z2`::
 
-e-folding depth for exponential porosity law for silt (double precision)
+e-folding depth for exponential porosity law for sand (double precision)
 
 `r` ::
 
@@ -199,11 +199,11 @@ averaging depth/thickness needed to solve the silt-sand equation in meters (doub
 
 `kds1` ::
 
-marine transport coefficient (diffusivity) for sand in meters squared per year (double precision)
+marine transport coefficient (diffusivity) for silt in meters squared per year (double precision)
 
 `kds2` ::
 
-marine transport coefficient (diffusivity) for silt in meters squared per year (double precision)
+marine transport coefficient (diffusivity) for sand in meters squared per year (double precision)
 
 [WARNING]
 ====

--- a/docs/api.adoc
+++ b/docs/api.adoc
@@ -79,7 +79,7 @@ array of dimension `(nx*ny)` containing the initial topography in meters (double
 
 === FastScape_Init_F
 
-This routine is used to initialize the sand-shale ratio
+This routine is used to initialize the silt fraction
 
 Arguments:
 
@@ -87,7 +87,7 @@ Arguments:
 
 `F` ::
 
-array of dimension `(nx*ny)` containing the initial sand-shale ratio (double precision)
+array of dimension `(nx*ny)` containing the initial silt fraction (double precision)
 
 
 === FastScape_Set_Erosional_Parameters
@@ -179,7 +179,7 @@ reference/surface porosity for sand (double precision)
 
 `p2`::
 
-reference/surface porosity for shale (double precision)
+reference/surface porosity for silt (double precision)
 
 `z1`::
 
@@ -187,15 +187,15 @@ e-folding depth for exponential porosity law for sand (double precision)
 
 `z2`::
 
-e-folding depth for exponential porosity law for shale (double precision)
+e-folding depth for exponential porosity law for silt (double precision)
 
 `r` ::
 
-sand-shale ratio for material leaving the continent (double precision)
+silt fraction for material leaving the continent (double precision)
 
 `L` ::
 
-averaging depth/thickness needed to solve the sand-shale equation in meters (double precision)
+averaging depth/thickness needed to solve the silt-sand equation in meters (double precision)
 
 `kds1` ::
 
@@ -203,7 +203,7 @@ marine transport coefficient (diffusivity) for sand in meters squared per year (
 
 `kds2` ::
 
-marine transport coefficient (diffusivity) for shale in meters squared per year (double precision)
+marine transport coefficient (diffusivity) for silt in meters squared per year (double precision)
 
 [WARNING]
 ====
@@ -387,7 +387,7 @@ array of dimension `(nx*ny)` containing the extracted topography in meters (doub
 
 === FastScape_Copy_F
 
-This routine is used to extract from the model the current sand-shale ratio
+This routine is used to extract from the model the current silt fraction
 
 Arguments:
 
@@ -395,7 +395,7 @@ Arguments:
 
 `F` ::
 
-array of dimension `(nx*ny)` containing the extracted sand-shale ratio (double precision)
+array of dimension `(nx*ny)` containing the extracted silt fraction (double precision)
 
 === FastScape_Copy_Basement
 
@@ -639,7 +639,7 @@ What is stored on each horizon:
 |5|DepositionalBathymetry|Bathymetry at time of deposition in meters
 |6|DepositionalSlope| Slope at time of depostion in degrees
 |7|DistanceToSHore| Distance to shore at time of deposition in meters
-|8|Sand/ShaleRatio|Sand to shale ratio at time of deposition
+|8|Sand/ShaleRatio|Silt fraction at time of deposition
 |9|HorizonAge|Age of the current horizon in years
 |A|ThicknessErodedBelow|Sediment thickness eroded below current horizon in meters
 |===

--- a/src/FastScape_api.f90
+++ b/src/FastScape_api.f90
@@ -43,13 +43,13 @@
 ! FastScape_Set_Marine_Parameters (sealevel, poro1, poro2, zporo1, zporo2, ratio, length, kds1, kds2)
 ! sets the value of the marine transport parameters
 ! sl is sea level (in m)
-! poro1 is surface porosity for shale (dimensionless)
+! poro1 is surface porosity for silt (dimensionless)
 ! poro2 is surface porosity for sand (dimensionless)
-! zporo1 is e-folding porosity depth for shale (in m)
+! zporo1 is e-folding porosity depth for silt (in m)
 ! zporo2 is e-folding porosity depth for sand (in m)
 ! ratio is the ratio of sand in the incoming flux from the continent (dimensionless)
 ! length is the thickness of the "mixed" surface layer (in m) at the bottom of the ocean
-! kds1 and kds2 are the marine transport coefficients (diffusivities) for shale and sand respectively (in m^2/yr)
+! kds1 and kds2 are the marine transport coefficients (diffusivities) for silt and sand respectively (in m^2/yr)
 
 ! FastScape_Set_DT (dt)
 ! sets the time step length (in yr)
@@ -78,7 +78,7 @@
 ! h is double precision of size nn
 
 ! FastScape_Init_F (F)
-! sets the initial sand to shale ratio to F
+! sets the initial silt fraction to F
 ! an array of dimension nn(=nx*ny) should be passed
 ! F is double precision of size nn
 
@@ -93,7 +93,7 @@
 ! b is double precision of size nn
 
 ! FastScape_Copy_F (F)
-! returns the current surface sand-to-shale ratio (in m)
+! returns the current surface silt fraction (in m)
 ! as an array of dimension nn(=nx*ny)
 ! F is double precision of size nn
 

--- a/src/Strati.f90
+++ b/src/Strati.f90
@@ -59,7 +59,7 @@ subroutine Strati (b,F,nx,ny,xl,yl,reflector,nreflector,ireflector,istep,fields,
   names(5) = '5.DepositionalBathymetry(m)'
   names(6) = '6.DepositionalSlope(Deg)'
   names(7) = '7.DistanceToShore(m)'
-  names(8) = '8.Sand/ShaleRatio'
+  names(8) = '8.SiltFraction'
   names(9) = '9.ReflectorAge(yr)'
   names(10) = 'A.ThicknessErodedBelow(m)'
 


### PR DESCRIPTION
This PR updates the online documentation and the comments in Fastscape_api.f90 to
* use the term 'silt fraction' instead of 'sand-shale ratio'. 
* replace 'shale' by 'silt'. 
* switch the online description of the order of sand and silt variables in the FastScape_Set_Marine_Parameters function.

These changes unify the terminology with that used in Marine.f90 and the paper by Yuan et al. (2019) in EPSL. The order of the FastScape_Set_Marine_Parameters arguments in the manual is now also in agreement with the order specified in lines 43-52 of FastScape_api.f90.

Only in Strati.f90 is `Sand/ShaleRatio` still used as output parameter name (line 62); I didn't change it because it actually changes the output, not just the documentation. Let me know if I should also change that parameter name.

FYI @Djneu