### PR TITLE
Set flag transition ocean continent

### DIFF
--- a/src/Marine.f90
+++ b/src/Marine.f90
@@ -41,6 +41,10 @@ subroutine Marine()
 
   ! set nodes at transition between ocean and continent
   !where (flux.gt.tiny(flux)) flag=1
+  do ij=1,nn
+    ijr=rec(ij)
+    if (h(ij).ge.sealevel.and.h(ijr).le.sealevel) flag(ijr)=1
+  enddo
 
   ! decompact volume of pure solid phase (silt and sand) from onshore
   ratio1=ratio/(1.d0-poro1)


### PR DESCRIPTION
I noticed that the amount of sediments in the marine domain increases for increasing the marine diffusivity, even for zero continental sediment input. I also noticed that the flag that defines whether a node is on the boundary between the continental and the marine domain is used, but not set to something other than its default value 0. 

After discussing this with Xiaoping, he suggested making this modification to Marine.f90 that does set the flag to 1 at the boundary. Xiaoping has used this fix in his version of the code as well. I verified that the flag values change in space over time following the boundary.

The snapshot below shows the surface of two simulations without continental erosion and a very small continent at a certain moment in time. One run does not change the flag from 0 (i.e., current version, red interface), while the other sets the flag to 1 at the transition from continent to ocean (green interface). The initially vertical margin does not change over time in the green version, as there is no continental input. In the red simulation artificial sediment is built up as the margin diffuses.

<img width="1311" alt="Small_Continent_Margin_noCerosion_oldred_newgreen_km100" src="https://github.com/fastscape-lem/fastscapelib-fortran/assets/7631624/cf2b70f9-b682-4de3-a67d-ff4c00377238">

I will add more examples demonstrating the difference later. 
